### PR TITLE
Correction doc d'install MacOS

### DIFF
--- a/openfisca_web_site/templates/tree/installation.mako
+++ b/openfisca_web_site/templates/tree/installation.mako
@@ -319,9 +319,9 @@ paster serve --reload development.ini</pre>
         </li>
         <li>Afin de pouvoir lancer l'API, certain paquets sont nécessaires, pour les installer, lancer les commandes suivantes :
             <pre>sudo brew install git
-sudo brew install gfortran
-sudo brew install mongodb
-sudo brew install nodejs
+brew install gfortran
+brew install mongodb
+brew install nodejs
 sudo pip install babel
 sudo pip install isodate
 sudo pip install pandas
@@ -782,10 +782,10 @@ paster serve --reload development.ini</pre>
         <li>Installer <a href="http://brew.sh/index_fr.html">Homebrew</a>
         </li>
         <li>Afin de pouvoir lancer l'API, certain paquets sont nécessaires, pour les installer, lancer les commandes suivantes :
-            <pre>sudo brew install git
-sudo brew install gfortran
-sudo brew install mongodb
-sudo brew install nodejs
+            <pre>brew install git
+brew install gfortran
+brew install mongodb
+brew install nodejs
 sudo pip install babel
 sudo pip install isodate
 sudo pip install pandas


### PR DESCRIPTION
La commande sudo utilisé avec brew renvoie l'erreur suivante :

"Error: Cowardly refusing to `sudo brew install`
You can use brew with sudo, but only if the brew executable is owned by root.
However, this is both not recommended and completely unsupported so do so at
your own risk."

Brew fonctionne sans sudo pour les install chez moi, de même pour pip (pas besoin de sudo) mais ça ne me fait pas planter l'exécution (à vous de voir si il faut les supprimer).
