### PR TITLE
Explain how to install the site locally

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,0 +1,20 @@
+#Install procedure
+
+To install and serve the OpenFisca France website locally :
+
+A/ Install the following packages:
+```SH
+pip install pastescript
+brew install libmagic
+brew install bower
+```
+
+B/ Run the following commands:
+```SH
+pip install -e .
+bower install
+```
+
+C/ Serve locally:
+`paster serve development-france.ini`
+Visit `http://127.0.0.1:2010` to see the website.


### PR DESCRIPTION
Adds a short procedure to install the site locally.
This procedure has not been thoroughly tested, it is there to informally help the team when making changes to the website.